### PR TITLE
Allow to link against clangTooling provided in libclang-cpp + LLVM15 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ option(TSEPEPE_ENABLE_TESTING "Enable testing of this project" OFF)
 find_package(LLVM 14 REQUIRED)
 find_package(Clang REQUIRED)
 
+# clangTooling may be either provided as individual libraries or as a bundled libclang-cpp lib
+find_library(CLANGTOOLING_LIBRARY NAMES clangTooling clang-cpp)
+add_library(clangTooling SHARED IMPORTED)
+set_target_properties(clangTooling PROPERTIES IMPORTED_LOCATION ${CLANGTOOLING_LIBRARY})
+
 add_compile_options(-Wall)
 
 include(cmake/dependencies.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(TSEPEPE_ENABLE_TESTING "Enable testing of this project" OFF)
 
-find_package(LLVM 14 REQUIRED)
+find_package(LLVM REQUIRED)
+if(LLVM_VERSION_MAJOR LESS 14)
+    message(FATAL_ERROR "LLVM >= 14 is required")
+endif()
 find_package(Clang REQUIRED)
 
 # clangTooling may be either provided as individual libraries or as a bundled libclang-cpp lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,14 @@ if(LLVM_VERSION_MAJOR LESS 14)
 endif()
 find_package(Clang REQUIRED)
 
-# clangTooling may be either provided as individual libraries or as a bundled libclang-cpp lib
-find_library(CLANGTOOLING_LIBRARY NAMES clangTooling clang-cpp)
-add_library(clangTooling SHARED IMPORTED)
-set_target_properties(clangTooling PROPERTIES IMPORTED_LOCATION ${CLANGTOOLING_LIBRARY})
+if(NOT TARGET clangTooling)
+    # clangTooling may be either provided as individual libraries or as a bundled libclang-cpp lib
+    find_library(CLANGTOOLING_LIBRARY NAMES clangTooling clang-cpp)
+    add_library(clangTooling SHARED IMPORTED)
+    set_target_properties(clangTooling PROPERTIES IMPORTED_LOCATION ${CLANGTOOLING_LIBRARY})
+else()
+    message(STATUS "Tsepepe: found clangTooling bundled with Clang package")
+endif()
 
 add_compile_options(-Wall)
 

--- a/src/abstract_class_finder/CMakeLists.txt
+++ b/src/abstract_class_finder/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(tsepepe_abstract_class_finder tool.cpp cmd_parser.cpp finder.cpp)
 
 target_include_directories(tsepepe_abstract_class_finder PRIVATE ${LLVM_INCLUDE_DIR})
 target_link_libraries(tsepepe_abstract_class_finder PRIVATE 
-    LLVMSupport clangTooling tsepepe_utils Boost::headers range-v3::range-v3)
+    LLVM LLVMSupport clangTooling tsepepe_utils Boost::headers range-v3::range-v3)
 
 target_compile_options(tsepepe_abstract_class_finder PRIVATE -Wno-deprecated-enum-enum-conversion)
 

--- a/src/full_class_name_expander/CMakeLists.txt
+++ b/src/full_class_name_expander/CMakeLists.txt
@@ -2,5 +2,5 @@ add_executable(tsepepe_full_class_name_expander tool.cpp expander.cpp cmd_parser
 
 target_include_directories(tsepepe_full_class_name_expander PRIVATE ${LLVM_INCLUDE_DIR})
 target_link_libraries(tsepepe_full_class_name_expander PRIVATE 
-    LLVMSupport clangTooling tsepepe_utils)
+    LLVM LLVMSupport clangTooling tsepepe_utils)
 

--- a/src/function_definition_generator/CMakeLists.txt
+++ b/src/function_definition_generator/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(tsepepe_function_definition_generator tool.cpp cmd_parser.cpp)
 
 target_include_directories(tsepepe_function_definition_generator PRIVATE ${LLVM_INCLUDE_DIR})
-target_link_libraries(tsepepe_function_definition_generator PRIVATE tsepepe_utils tsepepe_lib LLVMSupport clangTooling)
+target_link_libraries(tsepepe_function_definition_generator PRIVATE tsepepe_utils tsepepe_lib LLVM LLVMSupport clangTooling)
 
 target_compile_options(tsepepe_function_definition_generator PRIVATE -Wno-deprecated-enum-enum-conversion)
 

--- a/src/implementor_maker/CMakeLists.txt
+++ b/src/implementor_maker/CMakeLists.txt
@@ -2,6 +2,6 @@ add_executable(tsepepe_implementor_maker tool.cpp cmd_parser.cpp)
 
 target_include_directories(tsepepe_implementor_maker PRIVATE ${LLVM_INCLUDE_DIR})
 target_link_libraries(tsepepe_implementor_maker PRIVATE
-    LLVMSupport clangTooling tsepepe_utils tsepepe_lib)
+    LLVM LLVMSupport clangTooling tsepepe_utils tsepepe_lib)
 
 install(TARGETS tsepepe_implementor_maker)

--- a/src/pure_virtual_functions_extractor/CMakeLists.txt
+++ b/src/pure_virtual_functions_extractor/CMakeLists.txt
@@ -2,5 +2,5 @@ add_executable(tsepepe_pure_virtual_functions_extractor tool.cpp extractor.cpp c
 
 target_include_directories(tsepepe_pure_virtual_functions_extractor PRIVATE ${LLVM_INCLUDE_DIR})
 target_link_libraries(tsepepe_pure_virtual_functions_extractor PRIVATE 
-    LLVMSupport clangTooling tsepepe_utils)
+    LLVM LLVMSupport clangTooling tsepepe_utils)
 

--- a/src/suitable_place_in_class_finder/CMakeLists.txt
+++ b/src/suitable_place_in_class_finder/CMakeLists.txt
@@ -2,4 +2,4 @@ add_executable(tsepepe_suitable_place_in_class_finder tool.cpp finder.cpp cmd_pa
 
 target_include_directories(tsepepe_suitable_place_in_class_finder PRIVATE ${LLVM_INCLUDE_DIR})
 target_link_libraries(tsepepe_suitable_place_in_class_finder PRIVATE 
-    LLVMSupport clangTooling Boost::headers tsepepe_utils)
+    LLVM LLVMSupport clangTooling Boost::headers tsepepe_utils)


### PR DESCRIPTION
This contains a couple fixes so that this project builds on more distros:

- We need to explicitly link against LLVM because LLVM is defined as `DT_NEEDED` in `libclang-cpp`, which means that without `"-Wl,--copy-dt-needed-entries"` the linking step would always fail, because `libLLVM.so` is not given
- Allow to link against `libclang-cpp.so` instead of `libclangTooling.so`, as some distros (such as Arch Linux or NixOS) build clang like this
- Allow `find_package()` to find LLVM15 instead of hardcoding LLVM14