### PR TITLE
Fix build with clang16

### DIFF
--- a/src/include/libclang_utils/token_iterator.hpp
+++ b/src/include/libclang_utils/token_iterator.hpp
@@ -44,7 +44,7 @@ struct TokenIterator : std::forward_iterator_tag
 
     reference operator*() const
     {
-        if (not current_token.hasValue())
+        if (not current_token.has_value())
             throw Tsepepe::BaseError{"Dereferencing invalid token!"};
         return *current_token;
     }
@@ -57,7 +57,7 @@ struct TokenIterator : std::forward_iterator_tag
     //! Prefix increment
     TokenIterator& operator++()
     {
-        if (not current_token.hasValue())
+        if (not current_token.has_value())
             return *this;
         current_token = clang::Lexer::findNextToken(current_token->getLocation(), *source_manager, *lang_options);
         return *this;

--- a/src/src/libclang_utils/suitable_place_in_class_finder.cpp
+++ b/src/src/libclang_utils/suitable_place_in_class_finder.cpp
@@ -148,7 +148,7 @@ struct SuitablePlaceInClassFinder
 
     SourceLocation unpack_source_location_from_token(const Optional<Token>& token) const
     {
-        if (not token.hasValue())
+        if (not token.has_value())
             throw Tsepepe::BaseError{"Can't unpack token; token empty!"};
 
         auto loc{token->getLocation()};


### PR DESCRIPTION
clang::Optional is now internally a typedef for std::optional.

Do you think we need `#ifdef`s to support older clang versions too, or is supporting just the latest version ok?
